### PR TITLE
[병합] 모집 공고 조회 페이지네이션 조건 삭제 및 이벤트 삭제

### DIFF
--- a/src/repositories/projects.repository.js
+++ b/src/repositories/projects.repository.js
@@ -69,7 +69,6 @@ class ProjectRepository {
           [Op.and]: {
             id: { [Op.gt]: cursor },
             status,
-            deletedAt: { [Op.eq]: null },
           },
         },
         raw: true,

--- a/src/static/js/cursorPagination.js
+++ b/src/static/js/cursorPagination.js
@@ -3,6 +3,10 @@ const pagination = document.getElementById('pagination');
 
 const handleScroll = async () => {
   let end = projectsBox.clientHeight + projectsBox.scrollTop;
+  if (!cursor) {
+    projectsBox.removeEventListener('scroll', handleScroll);
+    return;
+  }
   if (end === projectsBox.scrollHeight) {
     const response = await fetch(
       `http://localhost:3000/api/projects?cursor=${cursor}&site=${site}`


### PR DESCRIPTION
소프트 삭제는 자동으로 체크되어서 커서 기반 전체 프로젝트 조회에서 deletedAt 조건 삭제
커서 페이지네이션 프론트에서 마지막 공고 조회 시 무한 스크롤 이벤트 삭제