### PR TITLE
[병합] 팀조회, 관리 기능 추가 및 개선 / 채팅창 렌더링 개선

### DIFF
--- a/src/controllers/chats.controller.js
+++ b/src/controllers/chats.controller.js
@@ -20,7 +20,7 @@ class ChatsController {
 
   renderPrivateChatPage = async (req, res, next) => {
     const { teamId, memberId } = req.params;
-    const userId = 5; // req.cookies.userId 등 임시구현
+    const { id: userId } = res.locals.user;
 
     const myMemberInfo = await this.teamService.findMemberIdByUserIdAndTeamId(
       userId,

--- a/src/controllers/chats.controller.js
+++ b/src/controllers/chats.controller.js
@@ -26,9 +26,11 @@ class ChatsController {
       userId,
       teamId
     );
-    const chatId = [myMemberInfo.id, memberId].sort((a, b) => a - b).join('$');
+    const chatId = [teamId, myMemberInfo.id, memberId]
+      .sort((a, b) => a - b)
+      .join('$');
 
-    const memberList = await this.teamService.findAllByTeamId(chatId);
+    const memberList = await this.teamService.findAllByTeamId(teamId);
     const chattingList = await this.chatService.findAllMessagesByChatId(chatId);
 
     return res.render('chat', { memberList, chattingList });

--- a/src/controllers/projects.controller.js
+++ b/src/controllers/projects.controller.js
@@ -134,7 +134,12 @@ class ProjectsController {
   //* 프로젝트 생성
   createProject = async (req, res) => {
     try {
+      const { id: userId } = res.locals.user;
+      const leaderPosition = 3;
+
       await this.projectService.createProject(req.body);
+      const teamId = await this.teamService.findMostRecentTeamByUserId(userId);
+      await this.teamService.addNewMember(leaderPosition, userId, teamId);
 
       return res.sendStatus(201);
     } catch (error) {

--- a/src/controllers/teams.controller.js
+++ b/src/controllers/teams.controller.js
@@ -11,9 +11,6 @@ class TeamsController {
 
   renderTeamPage = async (req, res, next) => {
     const { teamId } = req.params;
-    console.log(req.session.nickname);
-    console.log(req.sessionID);
-    console.log(req.headers.cookie.split('nickname=')[1]);
 
     try {
       const { teamName, status } =
@@ -25,6 +22,20 @@ class TeamsController {
         teamName,
         status,
         memberList,
+      });
+    } catch (error) {
+      return res.render('deletedTeam');
+    }
+  };
+
+  renderMyTeamListPage = async (req, res, next) => {
+    const { id } = res.locals.user;
+    const myTeamList = await this.teamService.findAllTeamByUserId(id);
+    console.log(myTeamList);
+    try {
+      return res.render('myTeamList', {
+        pageTitle: 'My Team List',
+        myTeamList,
       });
     } catch (error) {
       return res.render('deletedTeam');

--- a/src/controllers/teams.controller.js
+++ b/src/controllers/teams.controller.js
@@ -33,7 +33,7 @@ class TeamsController {
   renderMyTeamListPage = async (req, res, next) => {
     const { id } = res.locals.user;
     const myTeamList = await this.teamService.findAllTeamByUserId(id);
-    console.log(myTeamList);
+
     try {
       return res.render('myTeamList', {
         pageTitle: 'My Team List',

--- a/src/controllers/teams.controller.js
+++ b/src/controllers/teams.controller.js
@@ -11,6 +11,9 @@ class TeamsController {
 
   renderTeamPage = async (req, res, next) => {
     const { teamId } = req.params;
+    console.log(req.session.nickname);
+    console.log(req.sessionID);
+    console.log(req.headers.cookie.split('nickname=')[1]);
 
     try {
       const { teamName, status } =

--- a/src/controllers/teams.controller.js
+++ b/src/controllers/teams.controller.js
@@ -11,6 +11,7 @@ class TeamsController {
 
   renderTeamPage = async (req, res, next) => {
     const { teamId } = req.params;
+    const { nickname } = res.locals.user;
 
     try {
       const { teamName, status } =
@@ -22,6 +23,7 @@ class TeamsController {
         teamName,
         status,
         memberList,
+        nickname,
       });
     } catch (error) {
       return res.render('deletedTeam');
@@ -78,12 +80,11 @@ class TeamsController {
         userIdverifiedByNickname,
         teamId
       );
+      return res.status(201).json(newMember);
     } catch (error) {
       error.status = 500;
       throw error;
     }
-
-    return res.status(201).json(newMember);
   };
 
   updateTeam = async (req, res, next) => {

--- a/src/repositories/projects.repository.js
+++ b/src/repositories/projects.repository.js
@@ -53,6 +53,30 @@ class ProjectRepository {
     }
   };
 
+  findAllProjectsByUserId = async (owner) => {
+    try {
+      return await this.projectModel.findAll({
+        attributes: ['id', 'team_name', 'status', 'createdAt'],
+        where: { owner },
+        order: [['id', 'DESC']],
+      });
+    } catch (error) {
+      error.status = 500;
+      throw error;
+    }
+  };
+
+  findMostRecentIdByUserId = async (owner) => {
+    try {
+      return await this.projectModel.max('id', {
+        where: { owner },
+      });
+    } catch (error) {
+      error.status = 500;
+      throw error;
+    }
+  };
+
   findAllProjectByStatus = async (status) => {
     try {
       const projects = await this.projectModel.findAll({

--- a/src/repositories/projects.repository.js
+++ b/src/repositories/projects.repository.js
@@ -53,10 +53,27 @@ class ProjectRepository {
     }
   };
 
+  findAllTeamWithNickname = async () => {
+    try {
+      return await this.projectModel.findAll({
+        include: [
+          {
+            model: User,
+            attributes: ['nickname'],
+          },
+        ],
+        order: [['id', 'DESC']],
+      });
+    } catch (error) {
+      error.status = 500;
+      throw error;
+    }
+  };
+
   findAllProjectsByUserId = async (owner) => {
     try {
       return await this.projectModel.findAll({
-        attributes: ['id', 'team_name', 'status', 'createdAt'],
+        attributes: ['id', 'teamName', 'status', 'techStack', 'createdAt'],
         where: { owner },
         order: [['id', 'DESC']],
       });

--- a/src/routes/page.routes.js
+++ b/src/routes/page.routes.js
@@ -24,7 +24,11 @@ router.get('/test', checkToken, apiController.renderTestPage);
 router.get('/mypage', checkToken, usersController.renderMypage);
 router.get('/members', usersController.renderSearchUserPage);
 
-router.get('/chat/:teamId/:memberId', chatsController.renderPrivateChatPage);
-router.get('/chat/:chatId', chatsController.renderTeamChatPage);
+router.get(
+  '/chat/:teamId/:memberId',
+  checkToken,
+  chatsController.renderPrivateChatPage
+);
+router.get('/chat/:chatId', checkToken, chatsController.renderTeamChatPage);
 
 module.exports = router;

--- a/src/routes/page.routes.js
+++ b/src/routes/page.routes.js
@@ -16,7 +16,7 @@ const chatsController = new ChatsController();
 router.get('/', checkToken, projectsController.renderProjectsPage);
 router.get('/users');
 router.get('/projects', checkToken, projectsController.renderProjectsPage);
-router.get('/teams/:teamId', teamsController.renderTeamPage);
+router.get('/teams/:teamId', checkToken, teamsController.renderTeamPage);
 router.get('/login', checkLogin, apiController.renderLoginPage);
 router.get('/join', checkLogin, apiController.renderJoinPage);
 router.get('/test', checkToken, apiController.renderTestPage);

--- a/src/routes/page.routes.js
+++ b/src/routes/page.routes.js
@@ -16,6 +16,7 @@ const chatsController = new ChatsController();
 router.get('/', checkToken, projectsController.renderProjectsPage);
 router.get('/users');
 router.get('/projects', checkToken, projectsController.renderProjectsPage);
+router.get('/teams/me', checkToken, teamsController.renderMyTeamListPage);
 router.get('/teams/:teamId', checkToken, teamsController.renderTeamPage);
 router.get('/login', checkLogin, apiController.renderLoginPage);
 router.get('/join', checkLogin, apiController.renderJoinPage);

--- a/src/routes/projects.routes.js
+++ b/src/routes/projects.routes.js
@@ -11,7 +11,7 @@ const projectsController = new ProjectsController();
 const commentsController = new CommentsController();
 const teamsController = new TeamsController();
 
-router.post('/', projectsController.createProject);
+router.post('/', checkToken, projectsController.createProject);
 
 // Todo <정지우> projectId나 userId 가 없는 경우 처리해야 함.
 // 모집공고 상세 보기

--- a/src/services/teams.service.js
+++ b/src/services/teams.service.js
@@ -11,7 +11,7 @@ class TeamService {
 
   findAllTeam = async () => {
     try {
-      return await this.projectRepository.findAllProject();
+      return await this.projectRepository.findAllTeamWithNickname();
     } catch (error) {
       throw error;
     }

--- a/src/services/teams.service.js
+++ b/src/services/teams.service.js
@@ -17,6 +17,22 @@ class TeamService {
     }
   };
 
+  findAllTeamByUserId = async (userId) => {
+    try {
+      return await this.projectRepository.findAllProjectsByUserId(userId);
+    } catch (error) {
+      throw error;
+    }
+  };
+
+  findMostRecentTeamByUserId = async (userId) => {
+    try {
+      return await this.projectRepository.findMostRecentIdByUserId(userId);
+    } catch (error) {
+      throw error;
+    }
+  };
+
   findAllByTeamId = async (teamId) => {
     try {
       return await this.teamRepository.findAllByTeamId(teamId);

--- a/src/socket.js
+++ b/src/socket.js
@@ -1,5 +1,4 @@
 const SocketIO = require('socket.io');
-const auth = require('./middlewares/auth');
 
 module.exports = (http, app) => {
   const io = SocketIO(http);

--- a/src/socket.js
+++ b/src/socket.js
@@ -1,4 +1,5 @@
 const SocketIO = require('socket.io');
+const auth = require('./middlewares/auth');
 
 module.exports = (http, app) => {
   const io = SocketIO(http);

--- a/src/static/css/myTeamList.css
+++ b/src/static/css/myTeamList.css
@@ -1,0 +1,16 @@
+.myTeamList__row {
+  display: flex;
+  padding: 20px;
+  margin: 20px;
+  border: 2px solid black;
+  background: rgba(255, 182, 193, 0.4);
+  cursor: pointer;
+}
+
+.myTeamList__row > div {
+  padding: 0px 10px;
+}
+
+.myTeamList__row span {
+  color: gray;
+}

--- a/src/static/css/myteam.css
+++ b/src/static/css/myteam.css
@@ -92,3 +92,12 @@ tbody th {
 .now_team_status {
   border: 5px solid red;
 }
+
+.leader-display.authority {
+  display: none;
+}
+
+.disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/src/static/css/myteam.css
+++ b/src/static/css/myteam.css
@@ -96,8 +96,3 @@ tbody th {
 .leader-display.authority {
   display: none;
 }
-
-.disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}

--- a/src/static/js/chatting.js
+++ b/src/static/js/chatting.js
@@ -1,5 +1,7 @@
 const path = location.pathname.split('/');
 const { 2: teamId, 3: memberId } = path;
+const nickname = document.querySelector('#userNickname').textContent;
+console.log(nickname);
 
 const socket = io.connect(`http://localhost:3000/chat`);
 
@@ -13,7 +15,6 @@ document.forms.publish.onsubmit = function () {
   let outgoingMessage = this.message.value;
   this.message.value = '';
   const obj = { type: 'message', params: { value: outgoingMessage } };
-  const userId = 13; // 임시구현
   socket.emit('message', JSON.stringify(obj));
 
   fetch(`/chat/${teamId}`, {

--- a/src/static/js/join.js
+++ b/src/static/js/join.js
@@ -99,7 +99,6 @@ emailAuthCheckBtn.addEventListener('click', () => {
   const emailAuthCheck = document.getElementById('emailCheck').value;
 
   const authString = document.cookie.split('=')[1];
-  console.log(authString);
   if (authString !== emailAuthCheck) {
     return alert('인증번호가 틀렸습니다.');
   }

--- a/src/static/js/join.js
+++ b/src/static/js/join.js
@@ -99,7 +99,7 @@ emailAuthCheckBtn.addEventListener('click', () => {
   const emailAuthCheck = document.getElementById('emailCheck').value;
 
   const authString = document.cookie.split('=')[1];
-  // console.log(authString);
+  console.log(authString);
   if (authString !== emailAuthCheck) {
     return alert('인증번호가 틀렸습니다.');
   }

--- a/src/static/js/join.js
+++ b/src/static/js/join.js
@@ -99,7 +99,7 @@ emailAuthCheckBtn.addEventListener('click', () => {
   const emailAuthCheck = document.getElementById('emailCheck').value;
 
   const authString = document.cookie.split('=')[1];
-
+  // console.log(authString);
   if (authString !== emailAuthCheck) {
     return alert('인증번호가 틀렸습니다.');
   }

--- a/src/static/js/myteam/teamAddNew.js
+++ b/src/static/js/myteam/teamAddNew.js
@@ -7,7 +7,7 @@ function addNewMember() {
   const position = 1;
   inputUserNickname.value = '';
 
-  fetch(url, {
+  const response = fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -16,10 +16,10 @@ function addNewMember() {
       nickname,
       position,
     }),
-  })
-    .then((response) => response.json())
-    .then((data) => {
-      alert(data.message);
-      location.reload();
-    });
+  });
+  const { status } = response;
+  if (status !== 201) {
+    alert('닉네임을 찾을 수 없거나 이미 팀에 등록된 닉네임입니다.');
+    location.reload();
+  }
 }

--- a/src/views/allteam.html
+++ b/src/views/allteam.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
     <link rel="stylesheet" href="css/style.css" />
     <link rel="stylesheet" href="css/allteam.css" />
 
@@ -31,13 +31,13 @@
           </thead>
           <tbody>
             {% set status = ['모집', '준비', '진행중', '테스트', '종료'] %} {%
-            for team in allTeam %}
+            for team in allTeam %} {% if team.status !== 0 %}
             <tr class="allteam__rows" id="allteam__row-{{allTeam.id}}">
               <th>{{team.teamName}}</th>
               {% if team.owner === '' %}
               <th>미정</th>
               {% else %}
-              <th>{{team.owner}}</th>
+              <th>{{team.User.nickname}}</th>
               {% endif %}
 
               <th>{{status[team.status]}}</th>
@@ -46,7 +46,7 @@
               <th>{{team.projectStart}}</th>
               <th>{{team.projectEnd}}</th>
             </tr>
-            {% endfor %}
+            {% endif %} {% endfor %}
           </tbody>
         </table>
       </section>

--- a/src/views/chat.html
+++ b/src/views/chat.html
@@ -9,12 +9,15 @@
   </head>
   <body>
     <main class="teamChat__main">
+      <div id="userNickname" style="display: none;">nickname</div>
       <div class="teamChat__column">
         <div class="teamChat__rooms" onclick="teamChatting()"><div>팀 채팅</div></div>
         {% for member in memberList %}
+        
         <div class="teamChat__rooms" onclick="whispering({{member.id}})">
           <div>{{member.User.nickname}}</div>
         </div>
+        
         {% endfor %}
       </div>
       <div class="teamChat__column">

--- a/src/views/deletedTeam.html
+++ b/src/views/deletedTeam.html
@@ -7,6 +7,6 @@
     <title>deleted team</title>
   </head>
   <body>
-    <h1>이 팀은 삭제되었습니다.</h1>
+    <h1>팀을 찾을 수 없습니다.</h1>
   </body>
 </html>

--- a/src/views/myTeamList.html
+++ b/src/views/myTeamList.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
+    <link rel="stylesheet" href="/css/myTeamList.css" />
+    <link rel="stylesheet" href="/css/style.css" />
+    <title>{{pageTitle}} | NoAFK</title>
+  </head>
+  <body>
+    {% include "partials/page-header.html"%}
+    <main id="myTeamList__main">
+      {% set status = ['모집', '준비', '진행중', '테스트', '종료'] %} {% for
+      myTeam in myTeamList %} {% if myTeam.status !== 0 %}
+      <div
+        onclick="goTeamPage({{myTeam.id}})"
+        id="row-{{myTeam.id}}"
+        class="myTeamList__row"
+      >
+        <div class="myTeamList__name">
+          <span>팀명: </span>{{myTeam.teamName}}
+        </div>
+        <div class="myTeamList__name">
+          <span>기술스택: </span>{{myTeam.techStack}}
+        </div>
+        <div class="myTeamList__status">
+          <span>상태: </span>{{status[myTeam.status]}}
+        </div>
+        <div class="myTeamList__createdAt">
+          <span>생성일: </span>{{myTeam.createdAt}}
+        </div>
+      </div>
+      {% endif %} {% endfor %}
+    </main>
+    {% include "partials/page-footer.html"%}
+    <script
+      src="https://kit.fontawesome.com/d1f609d41d.js"
+      crossorigin="anonymous"
+    ></script>
+    <script>
+      function goTeamPage(teamId) {
+        location.href = `/teams/${teamId}`;
+      }
+    </script>
+  </body>
+</html>

--- a/src/views/myteam.html
+++ b/src/views/myteam.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="images/favicon.ico" type="image/x-icon" />
     <link rel="stylesheet" href="/css/myteam.css" />
     <link rel="stylesheet" href="/css/style.css" />
     <title>{{pageTitle}} | NoAFK</title>
@@ -33,13 +33,15 @@
             member in memberList %} {% if member.position !== 0 %}
             <tr id="row-{{member.id}}">
               <!-- <th>{{member.id}}</th> -->
+              {% if member.position === 3 %}
+              <th id="teamLeader">{{member.User.nickname}}</th>
+              {% else %}
               <th>{{member.User.nickname}}</th>
+              {% endif %}
               <th>{{member.createdAt}}</th>
-
               <th id="position-{{member.id}}" data-value="{{member.position}}">
                 {{position[member.position]}}
               </th>
-
               <th id="task-{{member.id}}">{{member.task}}</th>
               <th>
                 <button
@@ -55,7 +57,7 @@
               >
                 <div>
                   <button
-                    class="myteam__memberList__update"
+                    class="leader-display"
                     onclick="updateMember({{member.id}})"
                   >
                     수정
@@ -63,7 +65,7 @@
                 </div>
                 <div>
                   <button
-                    class="myteam__memberList__emit"
+                    class="leader-display"
                     onclick="emitMember({{member.id}})"
                   >
                     방출
@@ -76,7 +78,7 @@
         </table>
       </section>
       <section id="myteam__searching-new">
-        <div>
+        <div class="leader-display">
           <span>팀원 추가하기</span
           ><input id="inputUserNickname" type="text" /><button
             id="addNewMemberBtn"
@@ -90,32 +92,36 @@
         <h2 id="myteam__project-status__title">프로젝트 현재 진행 상태</h2>
 
         <div id="myteam__project-status__buttons">
-          <button class="status-btn" data-num="0" onclick="updateTeamStatus(0)">
+          <button
+            class="status-btn leader-disable"
+            data-num="0"
+            onclick="updateTeamStatus(0)"
+          >
             모집마감</button
           ><span class="myteam__project-status__arrow">➡️</span
           ><button
-            class="status-btn"
+            class="status-btn leader-disable"
             data-num="1"
             onclick="updateTeamStatus(1)"
           >
             준비</button
           ><span class="myteam__project-status__arrow">➡️</span
           ><button
-            class="status-btn"
+            class="status-btn leader-disable"
             data-num="2"
             onclick="updateTeamStatus(2)"
           >
             진행중</button
           ><span class="myteam__project-status__arrow">➡️</span
           ><button
-            class="status-btn"
+            class="status-btn leader-disable"
             data-num="3"
             onclick="updateTeamStatus(3)"
           >
             테스트</button
           ><span class="myteam__project-status__arrow">➡️</span
           ><button
-            class="status-btn"
+            class="status-btn leader-disable"
             data-num="4"
             onclick="updateTeamStatus(4)"
           >
@@ -126,7 +132,9 @@
 
       <section id="myteam__footer">
         <div>
-          <button id="deleteTeam" onclick="deleteTeam()">팀 삭제</button>
+          <button class="leader-display" id="deleteTeam" onclick="deleteTeam()">
+            팀 삭제
+          </button>
           <button onclick="teamChatting()">팀 채팅</button>
         </div>
       </section>
@@ -137,6 +145,20 @@
       crossorigin="anonymous"
     ></script>
     <script>
+      const userNickname = `{{nickname}}`;
+      const teamLeader = document.querySelector('#teamLeader').textContent;
+      console.log(userNickname, teamLeader, userNickname !== teamLeader);
+
+      if (userNickname !== teamLeader) {
+        const displayElementList = document.querySelectorAll('.leader-display');
+        for (let displayElement of displayElementList) {
+          displayElement.classList.add('authority');
+        }
+        const disableElementList = document.querySelectorAll('.leader-disable');
+        for (let disableElement of disableElementList) {
+          disableElement.disabled = true;
+        }
+      }
       let nowStatus = document.querySelector(
         '.status-btn[data-num="{{status}}"]'
       );

--- a/src/views/partials/page-header.html
+++ b/src/views/partials/page-header.html
@@ -7,7 +7,7 @@
       <li><a href="#">프로젝트</a></li>
       <li><a href="/members">유저 조회</a></li>
       {% if user %}
-      <li><a href="#">나의 팀</a></li>
+      <li><a href="/teams/me">나의 팀</a></li>
 
       {% endif %}
       <li class="page-header__nav__search-bar">


### PR DESCRIPTION
[추가]
- 나의 팀 목록 페이지 및 API
- 팀관리 페이지 권한에 따른 설정 버튼 렌더링 개선
- 팀생성시 자동으로 공고생성자가 팀장으로 추가되도록 개선

[수정]
- 전체 팀조회시 상태 1이상만
- 전체 팀조회시 owner -> nickname 렌더링 되도록 개선
- 귓속말 채팅 렌더링 개선