### PR TITLE
[수정] 피드백 요청사항 개선

### DIFF
--- a/src/controllers/users.controller.js
+++ b/src/controllers/users.controller.js
@@ -182,6 +182,7 @@ class UsersController {
         image,
         expiredAt,
       } = userInfo;
+      const replaceImage = image.replace(/\/resizedProfile\//, '/profile/')
 
       res.status(200).render('mypage', {
         id,
@@ -191,6 +192,7 @@ class UsersController {
         testResult,
         introduction,
         image,
+        replaceImage,
         expiredAt,
         pageTitle: 'Mypage',
       });

--- a/src/static/css/mypage.css
+++ b/src/static/css/mypage.css
@@ -141,3 +141,26 @@ table.type09 td {
   font-size: 20px;
   font-weight: bolder;
 }
+
+#image_container img {
+  width: 250px;
+  height: 250px;
+}
+
+/* ( 크롬, 사파리, 오페라, 엣지 ) 동작 */
+.scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.scroll {
+  -ms-overflow-style: none; /* 인터넷 익스플로러 */
+  scrollbar-width: none; /* 파이어폭스 */
+}
+
+#submit-image {
+  margin-top: 150px;
+}
+
+#descText {
+  font-size: 14px;
+}

--- a/src/static/js/mypage.js
+++ b/src/static/js/mypage.js
@@ -19,18 +19,22 @@ function updateIntroduction() {
 function closeModalNickname() {
   document.getElementById('nicknameModal').style.display = 'none';
   document.body.style.overflow = 'auto';
+  window.location.reload();
 }
 function closeModalPassword() {
   document.getElementById('passwordModal').style.display = 'none';
   document.body.style.overflow = 'auto';
+  window.location.reload();
 }
 function closeModalImage() {
   document.getElementById('imageModal').style.display = 'none';
   document.body.style.overflow = 'auto';
+  window.location.reload();
 }
 function closeModalIntroduction() {
   document.getElementById('introductionModal').style.display = 'none';
   document.body.style.overflow = 'auto';
+  window.location.reload();
 }
 
 function submitNickname(id) {
@@ -60,7 +64,7 @@ function submitPassword(id) {
       fetch('/api/auth/logout');
     })
     .then(() => {
-      window.location.href = '/';
+      window.location.href = '/login';
     });
 }
 
@@ -118,4 +122,27 @@ function getInfo(id) {
         document.getElementById('progressUserProject').innerHTML += temp_html;
       }
     });
+}
+
+window.onkeyup = function(e) {
+	var key = e.keyCode ? e.keyCode : e.which;
+
+	if(key == 27) {
+		closeModalImage();
+    closeModalNickname();
+    closeModalPassword();
+    closeModalIntroduction();
+	}
+}
+
+function setThumbnail(event) {
+  var reader = new FileReader();
+
+  reader.onload = function(event) {
+    var img = document.createElement("img");
+    img.setAttribute("src", event.target.result);
+    document.querySelector("div#image_container").appendChild(img);
+  };
+
+  reader.readAsDataURL(event.target.files[0]);
 }

--- a/src/views/mypage.html
+++ b/src/views/mypage.html
@@ -17,7 +17,8 @@
           <h1>마이페이지</h1>
           <div id="user-info-header-box">
             <ul id="user-info-update">
-              {% if not testResult %}
+              {% if loginMethod === 'NoAFK' %}
+	            {% if not testResult %}
               <li id="user-info-update-content"><a href="/test">성향테스트</a></li>
               <li id="user-info-update-content" onclick="updateImage()">프로필사진 변경</li>
               <li id="user-info-update-content" onclick="updateNickname()">닉네임 변경</li>
@@ -29,12 +30,24 @@
               <li id="user-info-update-content" onclick="updatePassword()">비밀번호 변경</li>
               <li id="user-info-update-content" onclick="updateIntroduction()">자기소개 변경</li>
               {% endif %}
+	            {% else %}
+	            {% if not testResult %}
+              <li id="user-info-update-content"><a href="/test">성향테스트</a></li>
+              <li id="user-info-update-content" onclick="updateImage()">프로필사진 변경</li>
+              <li id="user-info-update-content" onclick="updateNickname()">닉네임 변경</li>
+              <li id="user-info-update-content" onclick="updateIntroduction()">자기소개 변경</li>
+              {% else %}
+              <li id="user-info-update-content" onclick="updateImage()">프로필사진 변경</li>
+              <li id="user-info-update-content" onclick="updateNickname()">닉네임 변경</li>
+              <li id="user-info-update-content" onclick="updateIntroduction()">자기소개 변경</li>
+              {% endif %}
+	            {% endif %}
             </ul>
           </div>
         </header>
       </section>
         <div id="user-profile">
-          <div id="user-profile-image"><img src="{{image}}" alt="프로필사진"></div>
+          <div id="user-profile-image"><img src="{{image}}" alt="프로필사진" onerror=this.src="{{replaceImage}}"></div>
           <div id="user-profile-info">
             <table class="type04" style="table-layout:fixed" width="100%">
               <tr>
@@ -73,7 +86,7 @@
               <br>
               <br>
               <br>
-              <input type="text" name="inputNickname">
+              <input type="text" name="inputNickname" onkeyup="if(window.event.keyCode==13){submitNickname({{id}})}">
               <button class="submit-btn" onclick="submitNickname({{id}})">변경</button>
             </div>
           </div>
@@ -88,9 +101,11 @@
               <br>
               (변경 후 자동 로그아웃)
               <br>
+              (로그인 페이지 이동)
               <br>
               <br>
-              <input type="password" name="inputPassword">
+              <br>
+              <input type="password" name="inputPassword" onkeyup="if(window.event.keyCode==13){submitPassword({{id}})}">
               <button class="submit-btn" onclick="submitPassword({{id}})">변경</button>
             </div>
           </div>
@@ -99,25 +114,19 @@
           <div class="modal_body">
             <div>프로필사진 변경</div>
             <button class="close-btn" onclick="closeModalImage()">X</button>
-            <div id="imageInput">
+            <div id="imageInput" class="scroll" style="overflow-x:hidden; height:300px;">
               변경할 이미지를 넣어주세요.
               <br>
               <br>
-              (최대 용량 : 4MB)
+              <div id="descText">
+                (최대 용량 : 4MB, .jpg/jpeg만 지원)
+              </div>
               <br>
-              (현재 .jpg/jpeg만 지원)
-              <br>
-              <br>
-              <input type="file" name="inputImage" id="inputImage" accept="image/*">
-              <button class="submit-btn" onclick="submitImage({{id}})">변경</button>
+              <input type="file" name="inputImage" id="inputImage" accept="image/*" onchange="setThumbnail(event);" onkeyup="if(window.event.keyCode==13){submitImage({{id}})}">
               <br>
               <br>
-              <br>
-              <br>
-              <br>
-              <br>
-              <br>
-              업로드 후 이미지 용량에 따라 보이는 것이 오래 걸릴 수 있습니다.
+              <div id="image_container"></div>
+              <button id="submit-image" class="submit-btn" onclick="submitImage({{id}})">변경</button>
             </div>
           </div>
         </div>
@@ -130,7 +139,7 @@
               <br>
               <br>
               <br>
-              <input type="text" name="inputIntroduction">
+              <input type="text" name="inputIntroduction" onkeyup="if(window.event.keyCode==13){submitIntroduction({{id}})}">
               <button class="submit-btn" onclick="submitIntroduction({{id}})">변경</button>
             </div>
           </div>
@@ -140,7 +149,7 @@
           <h1>참여 프로젝트</h1>
         </header>
       </section>
-      <div style="overflow-x:hidden; height:300px;">
+      <div class="scroll" style="overflow-x:hidden; height:300px;">
         <table class="type09" style="table-layout:fixed" width="100%">
           <thead>
           <tr>

--- a/src/views/test.html
+++ b/src/views/test.html
@@ -27,33 +27,33 @@
         <tr>
           <th scope="row">1. 나는 관심이 가는 사람에게 다가가서 대화를 시작하기가 어렵지 않다.</th>
           <td>
-            YES<input type="radio" name="IE" value="E" />
+            <label>YES<input type='radio' name='IE' value='E'id='YES'/></label>
             <br>
-            NO<input type="radio" name="IE" value="I" />
+            <label>NO<input type='radio' name='IE' value='I'id='NO'/></label>
           </td>
         </tr>
         <tr>
           <th scope="row">2. 나는 자유 시간 중 상당 부분을 다양한 관심사를 탐구하는 데 할애한다.</th>
           <td>
-            YES<input type="radio" name="NS" value="N" />
+            <label>YES<input type='radio' name='NS' value='N'id='YES'/></label>
             <br>
-            NO<input type="radio" name="NS" value="S" />
+            <label>NO<input type='radio' name='NS' value='S'id='NO'/></label>
           </td>
         </tr>
         <tr>
           <th scope="row">3. 나는 자신의 의견과 매우 다른 의견을 이해하기 위해 많은 시간을 할애하곤 한다.</th>
           <td>
-            YES<input type="radio" name="TF" value="F" />
+            <label>YES<input type='radio' name='TF' value='F'id='YES'/></label>
             <br>
-            NO<input type="radio" name="TF" value="T" />
+            <label>NO<input type='radio' name='TF' value='T'id='NO'/></label>
           </td>
         </tr>
         <tr>
           <th scope="row">4. 나는 여행계획을 세울 때 구체적으로 세우는 편이다.</th>
           <td>
-            YES<input type="radio" name="PJ" value="J" />
+            <label>YES<input type='radio' name='PJ' value='J'id='YES'/></label>
             <br>
-            NO<input type="radio" name="PJ" value="P" />
+            <label>NO<input type='radio' name='PJ' value='P'id='NO'/></label>
           </td>
         </tr>
       </table>


### PR DESCRIPTION
1. 비밀번호 변경 후 로그아웃 개선.
- 기존 : 변경 후 홈으로 이동.
- 변경 : 변경 후 로그인 페이지로 이동.

2. 정보 변경할 때 엔터키 사용 희망.
- 기존 : 엔터키 사용 불가.
- 변경 : 엔터키 사용 가능.
- 추가 : 정보 변경 취소시 ESC 사용 가능.

3. 프로필 사진 변경 후 이미지가 보이지 않는 문제.
- 기존 : 람다에서 이미지 리사이징 될때까지 이미지 안보임.
- 변경 : 람다에서 이미지 리사이징 되는동안 원본 이미지 출력.

4. 프로필 사진 변경 시 미리보기가 있으면 좋겠다고 함.
- 기존 : 미리보기 없음.
- 변경 : 프로필 사진 크기와 동일하게 이미지 미리보기 기능 추가.

5. 로컬 로그인을 제외한 비밀번호 변경 항목이 막혀있으면 좋겠다고 함.
- 기존 : 백엔드에서 변경이 되지 않도록 했으나 미동작.
- 변경 : 로그인 플랫폼 중 "NoAFK"를 제외한 모든 로그인은 비밀번호 변경 항목 제거.

6. 성향 테스트 선택칸이 작아 YES, NO 글자를 클릭해도 선택했으면 함.
- 기존 : 선택칸만 가능.
- 변경 : 텍스트 클릭도 가능.