### PR TITLE
[병합] 팀페이지 권한 오류 및 렌더링 수정, 채팅창 렌더링 수정

### DIFF
--- a/src/controllers/chats.controller.js
+++ b/src/controllers/chats.controller.js
@@ -17,7 +17,6 @@ class ChatsController {
       const invitedUserList = await this.teamService.findInvitedUserByTeamId(
         chatId
       );
-      console.log(invitedUserList);
       const chattingList = await this.chatService.findAllMessagesByChatId(
         chatId
       );

--- a/src/controllers/chats.controller.js
+++ b/src/controllers/chats.controller.js
@@ -14,14 +14,19 @@ class ChatsController {
       const { chatId, nickname } = req.params;
 
       const memberList = await this.teamService.findAllByTeamId(chatId);
+      const invitedUserList = await this.teamService.findInvitedUserByTeamId(
+        chatId
+      );
+      console.log(invitedUserList);
       const chattingList = await this.chatService.findAllMessagesByChatId(
         chatId
       );
 
       return res.render('chat', {
-        memberList,
-        chattingList,
         nickname,
+        memberList,
+        invitedUserList,
+        chattingList,
       });
     } catch (error) {
       return res.status(400).json({ message: error.message });
@@ -35,14 +40,18 @@ class ChatsController {
       const chatId = [teamId, nickname, memberNickname].sort().join('$');
 
       const memberList = await this.teamService.findAllByTeamId(teamId);
+      const invitedUserList = await this.teamService.findInvitedUserByTeamId(
+        teamId
+      );
       const chattingList = await this.chatService.findAllMessagesByChatId(
         chatId
       );
 
       return res.render('chat', {
-        memberList,
-        chattingList,
         nickname,
+        memberList,
+        invitedUserList,
+        chattingList,
       });
     } catch (error) {
       return res.status(400).json({ message: error.message });

--- a/src/controllers/teams.controller.js
+++ b/src/controllers/teams.controller.js
@@ -19,6 +19,9 @@ class TeamsController {
       const { nickname } = res.locals.user;
 
       const memberList = await this.teamService.findAllByTeamId(teamId);
+      const invitedUserList = await this.teamService.findInvitedUserByTeamId(
+        teamId
+      );
 
       if (memberList.length === 0) {
         return res.render('404', {
@@ -33,9 +36,10 @@ class TeamsController {
       return res.render('myteam', {
         pageTitle: 'My Team',
         teamName,
-        status,
-        memberList,
         nickname,
+        memberList,
+        invitedUserList,
+        status,
       });
     } catch (error) {
       return res.render('404', {

--- a/src/repositories/teams.repository.js
+++ b/src/repositories/teams.repository.js
@@ -32,7 +32,13 @@ class TeamRepository {
   findAllByTeamId = async (teamId) => {
     try {
       return await this.teamModel.findAll({
-        where: { projectId: teamId },
+        where: {
+          projectId: teamId,
+          [Op.and]: [
+            { position: { [Op.ne]: 0 } },
+            { position: { [Op.ne]: 4 } },
+          ],
+        },
         include: [
           {
             model: User,
@@ -40,6 +46,26 @@ class TeamRepository {
           },
         ],
         order: [['position', 'DESC']],
+      });
+    } catch (error) {
+      error.status = 500;
+      throw error;
+    }
+  };
+
+  findInvitedUserByTeamId = async (teamId) => {
+    try {
+      return await this.teamModel.findAll({
+        where: {
+          projectId: teamId,
+          position: 4,
+        },
+        include: [
+          {
+            model: User,
+            attributes: ['nickname'],
+          },
+        ],
       });
     } catch (error) {
       error.status = 500;

--- a/src/services/teams.service.js
+++ b/src/services/teams.service.js
@@ -110,6 +110,14 @@ class TeamService {
     }
   };
 
+  findInvitedUserByTeamId = async (teamId) => {
+    try {
+      return await this.teamRepository.findInvitedUserByTeamId(teamId);
+    } catch (error) {
+      throw error;
+    }
+  };
+
   findMemberIdByUserIdAndTeamId = async (userId, teamId) => {
     try {
       return await this.teamRepository.findMemberIdByUserIdAndTeamId(

--- a/src/static/css/teamChat.css
+++ b/src/static/css/teamChat.css
@@ -9,6 +9,7 @@ body {
 
 .teamChat__main {
   display: flex;
+
   height: 100%;
 }
 
@@ -95,6 +96,11 @@ body {
   font-weight: bold;
 }
 
+.chat-people-outer {
+  display: flex;
+  flex-direction: column;
+}
+
 .chat-people {
   height: 100%;
   overflow-y: auto;
@@ -104,6 +110,12 @@ body {
 
 .chat-people::-webkit-scrollbar {
   display: none; /* ( 크롬, 사파리, 오페라, 엣지 ) 동작 */
+}
+
+.invited-user > h3 {
+  padding-bottom: 5px;
+  margin-bottom: 15px;
+  border-bottom: 1px solid var(--light-gray);
 }
 
 .chat-screen {

--- a/src/views/chat.html
+++ b/src/views/chat.html
@@ -12,26 +12,50 @@
   <body>
     <main class="teamChat__main">
       <div id="userNickname" style="display: none">{{nickname}}</div>
-      <div class="teamChat__column chat-people">
-        <div class="teamChat__rooms" onclick="teamChatting()">
-          <div>팀 채팅</div>
+      <div class="chat-people-outer">
+        <div class="teamChat__column chat-people">
+          <div class="teamChat__rooms" onclick="teamChatting()">
+            <div>팀 채팅</div>
+          </div>
+          {% for member in memberList %} {% if member.User.nickname === nickname
+          %}
+          <div
+            class="teamChat__rooms"
+            onclick="whispering(`{{member.User.nickname}}`)"
+          >
+            <div>나</div>
+          </div>
+          {% else %}
+          <div
+            class="teamChat__rooms"
+            onclick="whispering(`{{member.User.nickname}}`)"
+          >
+            <div>{{member.User.nickname}}</div>
+          </div>
+          {% endif %} {% endfor %}
         </div>
-        {% for member in memberList %} {% if member.User.nickname === nickname
-        %}
-        <div
-          class="teamChat__rooms"
-          onclick="whispering(`{{member.User.nickname}}`)"
-        >
-          <div>나</div>
+
+        {% if invitedUserList.length === 0 %} {% else %}
+        <div class="teamChat__column chat-people invited-user">
+          <h3>예비 팀원</h3>
+          {% for invitedUser in invitedUserList %} {% if
+          invitedUser.User.nickname === nickname %}
+          <div
+            class="teamChat__rooms"
+            onclick="whispering(`{{invitedUser.User.nickname}}`)"
+          >
+            <div>나</div>
+          </div>
+          {% else %}
+          <div
+            class="teamChat__rooms"
+            onclick="whispering(`{{invitedUser.User.nickname}}`)"
+          >
+            <div>{{invitedUser.User.nickname}}</div>
+          </div>
+          {% endif %} {% endfor %}
         </div>
-        {% else %}
-        <div
-          class="teamChat__rooms"
-          onclick="whispering(`{{member.User.nickname}}`)"
-        >
-          <div>{{member.User.nickname}}</div>
-        </div>
-        {% endif %} {% endfor %}
+        {% endif %}
       </div>
       <div class="teamChat__column chat-screen">
         <!-- 수신받을 메시지가 노출될 div -->

--- a/src/views/myteam.html
+++ b/src/views/myteam.html
@@ -24,12 +24,11 @@
       </thead>
       <tbody>
         {% set position = ['신청자', '팀원', '부리더', '리더', '초대중'] %} {%
-        for member in memberList %} {% if member.position !== 0 %} {% if
-        member.position !== 4 %}
+        for member in memberList %}
         <tr id="row-{{member.id}}">
           <!-- <th>{{member.id}}</th> -->
           {% if member.position === 3 %}
-          <th id="teamLeader">{{member.User.nickname}}</th>
+          <th class="teamLeader">{{member.User.nickname}}</th>
           {% else %}
           <th>{{member.User.nickname}}</th>
           {% endif %}
@@ -67,7 +66,7 @@
             {% endif %}
           </th>
         </tr>
-        {% endif %} {% endif %} {% endfor %}
+        {% endfor %}
       </tbody>
     </table>
   </section>
@@ -82,6 +81,8 @@
       </button>
     </div>
   </section>
+  {% if invitedUserList.length === 0 %} {% else %}
+
   <section id="myteam__reserved-member" class="myteam__reserved-member">
     <header>
       <h1>예비 팀원</h1>
@@ -96,24 +97,30 @@
           <th>수락 / 거절</th>
         </tr>
       </thead>
-      {% for member in memberList %} {% if member.position === 4 %}
       <tbody class="invited-user__tbody">
-        <tr id="row-{{member.id}}">
+        {% for invitedUser in invitedUserList %}
+        <tr id="row-{{invitedUser.id}}">
           <!-- <th>{{member.id}}</th> -->
-          <th>{{member.User.nickname}}</th>
-          <th id="position-{{member.id}}" data-value="{{member.position}}">
-            {{position[member.position]}}
+          <th>{{invitedUser.User.nickname}}</th>
+          <th
+            id="position-{{invitedUser.id}}"
+            data-value="{{invitedUser.position}}"
+          >
+            {{position[invitedUser.position]}}
           </th>
           <th>
             <button
-              id="chat-{{member.id}}"
-              onclick="whispering(`{{member.User.nickname}}`)"
+              id="chat-{{invitedUser.id}}"
+              onclick="whispering(`{{invitedUser.User.nickname}}`)"
             >
               귓속말
             </button>
           </th>
-          <th class="myteam__memberList__config-btn" id="config-{{member.id}}">
-            {% if member.User.nickname === nickname %}
+          <th
+            class="myteam__memberList__config-btn"
+            id="config-{{invitedUser.id}}"
+          >
+            {% if invitedUser.User.nickname === nickname %}
             <div>
               <button onclick="agree('{{member.id}}')">수락</button>
             </div>
@@ -124,10 +131,11 @@
             {% endif %}
           </th>
         </tr>
+        {% endfor %}
       </tbody>
-      {% endif %} {% endfor %}
     </table>
   </section>
+  {% endif %}
   <section id="myteam__project-status">
     <h2 id="myteam__project-status__title">프로젝트 현재 진행 상태</h2>
 
@@ -181,12 +189,13 @@
 </main>
 <script>
   const userNickname = `{{nickname}}`;
-  let teamLeader = '';
-  if (document.querySelector('#teamLeader')) {
-    teamLeader = document.querySelector('#teamLeader').textContent;
+  let teamLeader = [];
+  if (document.querySelectorAll('.teamLeader')) {
+    for (let element of document.querySelectorAll('.teamLeader')) {
+      teamLeader.push(element.textContent);
+    }
   }
-
-  if (userNickname !== teamLeader) {
+  if (!teamLeader.includes(userNickname)) {
     const displayElementList = document.querySelectorAll('.leader-display');
     for (let displayElement of displayElementList) {
       displayElement.classList.add('authority');

--- a/src/views/myteam.html
+++ b/src/views/myteam.html
@@ -28,24 +28,24 @@
         <tr id="row-{{member.id}}">
           <!-- <th>{{member.id}}</th> -->
           {% if member.position === 3 %}
-          <th class="teamLeader">{{member.User.nickname}}</th>
+          <td class="teamLeader">{{member.User.nickname}}</td>
           {% else %}
-          <th>{{member.User.nickname}}</th>
+          <td>{{member.User.nickname}}</td>
           {% endif %}
-          <th>{{member.createdAt}}</th>
-          <th id="position-{{member.id}}" data-value="{{member.position}}">
+          <td>{{member.createdAt}}</td>
+          <td id="position-{{member.id}}" data-value="{{member.position}}">
             {{position[member.position]}}
-          </th>
-          <th id="task-{{member.id}}">{{member.task}}</th>
-          <th>
+          </td>
+          <td id="task-{{member.id}}">{{member.task}}</td>
+          <td>
             <button
               id="chat-{{member.id}}"
               onclick="whispering(`{{member.User.nickname}}`)"
             >
               귓속말
             </button>
-          </th>
-          <th class="myteam__memberList__config-btn" id="config-{{member.id}}">
+          </td>
+          <td class="myteam__memberList__config-btn" id="config-{{member.id}}">
             <div>
               <button
                 class="leader-display"
@@ -64,7 +64,7 @@
               </button>
             </div>
             {% endif %}
-          </th>
+          </td>
         </tr>
         {% endfor %}
       </tbody>
@@ -90,7 +90,6 @@
     <table class="invited-user">
       <thead class="invited-user__thead">
         <tr>
-          <!-- <th>번호</th> -->
           <th>이름</th>
           <th>상태</th>
           <th>귓속말</th>
@@ -100,23 +99,22 @@
       <tbody class="invited-user__tbody">
         {% for invitedUser in invitedUserList %}
         <tr id="row-{{invitedUser.id}}">
-          <!-- <th>{{member.id}}</th> -->
-          <th>{{invitedUser.User.nickname}}</th>
-          <th
+          <td>{{invitedUser.User.nickname}}</td>
+          <td
             id="position-{{invitedUser.id}}"
             data-value="{{invitedUser.position}}"
           >
             {{position[invitedUser.position]}}
-          </th>
-          <th>
+          </td>
+          <td>
             <button
               id="chat-{{invitedUser.id}}"
               onclick="whispering(`{{invitedUser.User.nickname}}`)"
             >
               귓속말
             </button>
-          </th>
-          <th
+          </td>
+          <td
             class="myteam__memberList__config-btn"
             id="config-{{invitedUser.id}}"
           >
@@ -129,7 +127,7 @@
               <button onclick="refuse('{{member.id}}')">거절</button>
             </div>
             {% endif %}
-          </th>
+          </td>
         </tr>
         {% endfor %}
       </tbody>


### PR DESCRIPTION
- 팀페이지 리더 권한 2인 이상일시 렌더링 오류 수정
- 팀페이지 예비 팀원 텍스트 0명일 때 아예 뜨지 않도록 수정
- 채팅창에 신청자는 뜨지 않도록 수정
- 채팅창에 초대자와 일반팀원 칸 분리